### PR TITLE
Do not minimize to system tray

### DIFF
--- a/src/org/yccheok/jstock/gui/JStock.java
+++ b/src/org/yccheok/jstock/gui/JStock.java
@@ -433,7 +433,7 @@ public class JStock extends javax.swing.JFrame {
                 formWindowDeiconified(evt);
             }
             public void windowIconified(java.awt.event.WindowEvent evt) {
-                formWindowIconified(evt);
+                //formWindowIconified(evt);
             }
         });
         getContentPane().setLayout(new java.awt.BorderLayout(5, 5));
@@ -1083,7 +1083,7 @@ public class JStock extends javax.swing.JFrame {
 
         if (Utils.isWindows())
         {
-            this.setVisible(false);
+            //this.setVisible(false);
         }
     }//GEN-LAST:event_formWindowIconified
 


### PR DESCRIPTION
When constantly switching back and forth between windows, having JStock
go to the system tray when minimized is EXTREMELY annoying and slows
down productivity. Commenting out these two lines should remove this
feature. I think you should seriously consider removing the system tray icon, and just minimize it to the task bar.